### PR TITLE
feat: complete macro target support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Plugins/PackageGenerator/PackageGenerator.swift
+++ b/Plugins/PackageGenerator/PackageGenerator.swift
@@ -34,6 +34,10 @@ struct PackageGenerator {
         acc[normalizedPath(testInfo.path)] = testInfo.exclude ?? []
       }
     }
+    let macroTargetPaths = Set(sanitizedPackageDirectories.compactMap { info -> String? in
+      guard info.target.isMacro else { return nil }
+      return normalizedPath(info.target.path)
+    })
     let testTargetNamesByPath = sanitizedPackageDirectories.reduce(into: [String: String]()) { acc, info in
       guard let testInfo = info.test else { return }
       let normalizedTestPath = normalizedPath(testInfo.path)
@@ -95,6 +99,9 @@ struct PackageGenerator {
       let normalizedFullPath = FileURL(fileURLWithPath: parsedPackage.fullPath).standardized.path
       if let excludes = excludesByPath[normalizedFullPath] {
         parsedPackage.exclude = excludes
+      }
+      if macroTargetPaths.contains(normalizedFullPath) {
+        parsedPackage.isMacro = true
       }
       return parsedPackage
     }
@@ -627,6 +634,7 @@ struct PackageGenerator {
     var last: String = ""
     for parsedPackage in parsedPackages.sorted(by: \.name, order: <) {
       if parsedPackage.isTest { continue }
+      if parsedPackage.isMacro { continue }
       if last.isEmpty == false {
         outputFileHandle.write("\(last),\n".data(using: .utf8)!)
       }
@@ -717,7 +725,7 @@ struct PackageGenerator {
     if configuration.leafInfo != true { isLeaf = "" }
     
     return """
-   \(spaces).\(fakeTarget.isTest ? "testTarget" : "target")(
+   \(spaces).\(fakeTarget.isTest ? "testTarget" : fakeTarget.isMacro ? "macro" : "target")(
    \(spaces)\(spaces)name: "\(name)",\(isLeaf)\(dependencies)
    \(spaces)\(spaces)path: "\(fakeTarget.path)"\(otherParameters)
    \(spaces))
@@ -813,6 +821,6 @@ struct PackageGenerator {
 
 private extension PackageInformation.PathInfo {
   func updatingPath(_ path: String) -> PackageInformation.PathInfo {
-    PackageInformation.PathInfo(path: path, name: name, exclude: exclude)
+    PackageInformation.PathInfo(path: path, name: name, exclude: exclude, isMacro: isMacro)
   }
 }

--- a/Plugins/PackageGenerator/PackageGeneratorConfiguration.swift
+++ b/Plugins/PackageGenerator/PackageGeneratorConfiguration.swift
@@ -127,13 +127,14 @@ struct PackageGeneratorConfiguration: Codable {
       enum TargetType: String, Codable {
         case regular
         case test
-        
+        case macro
+
         var defaultFolder: String {
           switch self {
-          case .regular:
+            case .regular, .macro:
             return "Sources"
-          case .test:
-            return "Tests"
+            case .test:
+              return "Tests"
           }
         }
       }
@@ -219,7 +220,7 @@ extension PackageGeneratorConfiguration {
 
   fileprivate func pathInfoWithResolvedExcludes(for info: PackageInformation.PathInfo) -> PackageInformation.PathInfo {
     let combined = combinedExcludes(for: info)
-    return PackageInformation.PathInfo(path: info.path, name: info.name, exclude: combined)
+    return PackageInformation.PathInfo(path: info.path, name: info.name, exclude: combined, isMacro: info.isMacro)
   }
 
   private func combinedExcludes(for info: PackageInformation.PathInfo) -> [String]? {
@@ -244,13 +245,13 @@ extension PackageGeneratorConfiguration {
 
 extension PackageGeneratorConfiguration.PackageDirectoryTargets {
   func packageInformations() -> [PackageInformation] {
-    let regularTargets = targets.filter { $0.type == .regular }
-    let regularNames = Set(regularTargets.map(\.name))
+    let nonTestTargets = targets.filter { $0.type == .regular || $0.type == .macro }
+    let nonTestNames = Set(nonTestTargets.map(\.name))
     var mappedTests: [String: Target] = [:]
     var unmatchedTests: [Target] = []
 
     for target in targets where target.type == .test {
-      if let regularName = regularTargetName(for: target), regularNames.contains(regularName) {
+      if let regularName = regularTargetName(for: target), nonTestNames.contains(regularName) {
         mappedTests[regularName] = target
       } else {
         unmatchedTests.append(target)
@@ -262,19 +263,20 @@ extension PackageGeneratorConfiguration.PackageDirectoryTargets {
     // target is found, we attach that test target to the first still-unpaired
     // regular target so it remains part of generation.
     for testTarget in unmatchedTests {
-      guard let fallbackRegular = regularTargets.first(where: { mappedTests[$0.name] == nil }) else {
+      guard let fallbackRegular = nonTestTargets.first(where: { mappedTests[$0.name] == nil }) else {
         continue
       }
       mappedTests[fallbackRegular.name] = testTarget
     }
 
-    return regularTargets.map { regular -> PackageInformation in
+    return nonTestTargets.map { target -> PackageInformation in
         let targetInfo = PackageInformation.PathInfo(
-          path: targetPath(for: regular),
-          name: regular.name,
-          exclude: regular.exclude
+          path: targetPath(for: target),
+          name: target.name,
+          exclude: target.exclude,
+          isMacro: target.type == .macro
         )
-        let testInfo = mappedTests[regular.name].map { test -> PackageInformation.PathInfo in
+        let testInfo = mappedTests[target.name].map { test -> PackageInformation.PathInfo in
           PackageInformation.PathInfo(
             path: targetPath(for: test),
             name: test.name,

--- a/Plugins/PackageGenerator/PackageInformation.swift
+++ b/Plugins/PackageGenerator/PackageInformation.swift
@@ -5,6 +5,26 @@ public struct PackageInformation: Codable {
     public let path: String
     public let name: String
     public let exclude: [String]?
+    public let isMacro: Bool
+
+    public init(path: String, name: String, exclude: [String]? = nil, isMacro: Bool = false) {
+      self.path = path
+      self.name = name
+      self.exclude = exclude
+      self.isMacro = isMacro
+    }
+
+    enum CodingKeys: CodingKey {
+      case path, name, exclude, isMacro
+    }
+
+    public init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.path = try container.decode(String.self, forKey: .path)
+      self.name = try container.decode(String.self, forKey: .name)
+      self.exclude = try container.decodeIfPresent([String].self, forKey: .exclude)
+      self.isMacro = try container.decodeIfPresent(Bool.self, forKey: .isMacro) ?? false
+    }
   }
   public let test: PathInfo?
   public let target: PathInfo

--- a/Plugins/PackageGenerator/ParsedPackage.swift
+++ b/Plugins/PackageGenerator/ParsedPackage.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct ParsedPackage: Codable, CustomStringConvertible {
   public var name: String
   public var isTest: Bool
+  public var isMacro: Bool = false
   public var dependencies: [String]
   public var path: String
   public var fullPath: String
@@ -14,6 +15,7 @@ public struct ParsedPackage: Codable, CustomStringConvertible {
   enum CodingKeys: String, CodingKey {
     case name
     case isTest
+    case isMacro
     case dependencies
     case path
     case fullPath
@@ -27,6 +29,7 @@ public struct ParsedPackage: Codable, CustomStringConvertible {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.name = try container.decode(String.self, forKey: .name)
     self.isTest = try container.decode(Bool.self, forKey: .isTest)
+    self.isMacro = try container.decodeIfPresent(Bool.self, forKey: .isMacro) ?? false
     self.dependencies = try container.decodeIfPresent([String].self, forKey: .dependencies) ?? []
     self.path = try container.decode(String.self, forKey: .path)
     self.fullPath = try container.decode(String.self, forKey: .fullPath)
@@ -44,9 +47,10 @@ public struct ParsedPackage: Codable, CustomStringConvertible {
     return "[\(dependencies.count)|\(localDependencies)] \(name) \(hasResources == false ? "" : "/ hasResources")"
   }
   
-  public init(name: String, isTest: Bool, dependencies: [String], path: String, fullPath: String, resources: String? = nil, localDependencies: Int = 0, hasBiggestNumberOfDependencies: Bool = false, exclude: [String] = []) {
+  public init(name: String, isTest: Bool, isMacro: Bool = false, dependencies: [String], path: String, fullPath: String, resources: String? = nil, localDependencies: Int = 0, hasBiggestNumberOfDependencies: Bool = false, exclude: [String] = []) {
     self.name = name
     self.isTest = isTest
+    self.isMacro = isMacro
     self.dependencies = dependencies
     self.path = path
     self.fullPath = fullPath


### PR DESCRIPTION
- Add isMacro to PackageInformation.PathInfo with backward-compatible decoding
- Update packageInformations() to include macro targets alongside regular targets
- Preserve isMacro in pathInfoWithResolvedExcludes and updatingPath helpers
- Add isMacro to ParsedPackage, decoded with default false for existing data
- Build macroTargetPaths set from sanitized config and stamp parsed packages
- Emit .macro(...) in fakeTargetToSwiftCode for macro targets
- Skip macro targets in generateProducts (macros don't get library products)