### PR TITLE
fix: double nested path

### DIFF
--- a/Plugins/PackageGenerator/PackageGeneratorConfiguration.swift
+++ b/Plugins/PackageGenerator/PackageGeneratorConfiguration.swift
@@ -161,6 +161,11 @@ struct PackageGeneratorConfiguration: Codable {
       }
 
       let folder = target.type.defaultFolder
+      // If the group path already ends with the target name, it IS the target directory.
+      // Avoid producing a double-nested path like Sources/OrderDetail/Sources/OrderDetail.
+      if URL(fileURLWithPath: path).lastPathComponent == target.name {
+        return path
+      }
       let base = (path as NSString).appendingPathComponent(folder)
       return (base as NSString).appendingPathComponent(target.name)
     }


### PR DESCRIPTION
Bug Fix: Incorrect target path for single-target groups

Problem

When a PackageDirectoryTargets group has a single regular target whose name matches the last path component of the group's path (e.g. path: "Sources/OrderDetail" with target.name: "OrderDetail"), the generated Package.swift contained the wrong source path.

The default branch of targetPath(for:) was unconditionally appending defaultFolder/targetName to the group path, producing:

 Sources/OrderDetail + Sources + OrderDetail = Sources/OrderDetail/Sources/OrderDetail

Since that directory doesn't exist, sanitizePathInfo fell through to buildDirectoryMap, which scanned the entire Sources tree and returned the first directory named OrderDetail it encountered — in this case Sources/AnalyticsLibraries/Events/OrderDetail — causing an overlapping
sources error at build time.

Fix

In the default (no path override) branch of targetPath(for:), if the group path already ends with the target name, return path directly — it is the target directory.

 if URL(fileURLWithPath: path).lastPathComponent == target.name {
     return path
 }

This handles the common convention where a single-target group's path points directly at the target's source folder, while leaving multi-target groups (where path doesn't end with the target name) unchanged.

Impact

 - Fixes incorrect source path resolution for single-target groups whose group path ends with the target name
 - No change in behaviour for multi-target groups or targets with explicit path overrides